### PR TITLE
Migrate to null-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.0
+
+  * Migrate to sound null-safety
+
 ## 0.2.1
 
   * Update http dependency.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -13,3 +13,7 @@ linter:
     - test_types_in_equals
     - unrelated_type_equality_checks
     - valid_regexps
+
+analyzer:
+  errors:
+    omit_local_variable_types: ignore

--- a/example/redux_api_middleware_example.dart
+++ b/example/redux_api_middleware_example.dart
@@ -20,6 +20,7 @@ void main() {
   // Next, apply the `apiMiddleware` to the Store
   final store = Store<String>(
     reducer,
+    initialState: '',
     middleware: [apiMiddleware],
   );
 

--- a/lib/src/errors.dart
+++ b/lib/src/errors.dart
@@ -22,15 +22,11 @@ class RequestError extends Error {
 
 class APIError extends Error {
   final String name = 'APIError';
-  String message;
-  int status;
-  String statusText;
-  dynamic response;
+  final String message;
+  final int status;
+  final String? statusText;
+  final dynamic response;
 
-  APIError(int status, String statusText, dynamic response) {
-    this.status = status;
-    this.statusText = statusText;
-    this.response = response;
-    this.message = '${status} - ${statusText}';
-  }
+  APIError(this.status, this.statusText, this.response)
+      : message = '$status - $statusText';
 }

--- a/lib/src/middleware.dart
+++ b/lib/src/middleware.dart
@@ -43,7 +43,6 @@ void apiMiddleware<State>(
   var headers = callAPI['headers'];
   var options = callAPI['options'];
   var method = callAPI['method'];
-  var credentials = callAPI['credentials'];
   var bailout = callAPI['bailout'];
   var types = callAPI['types'];
 
@@ -54,7 +53,8 @@ void apiMiddleware<State>(
   TypeDescriptor failureType = types[2];
 
   try {
-    if ((bailout is bool && bailout) || (bailout is Function && bailout(store.state))) {
+    if ((bailout is bool && bailout) ||
+        (bailout is Function && bailout(store.state))) {
       return;
     }
   } catch (e) {

--- a/lib/src/type_descriptor.dart
+++ b/lib/src/type_descriptor.dart
@@ -1,13 +1,11 @@
-import 'package:meta/meta.dart';
-
 class TypeDescriptor {
   final String type;
   dynamic payload;
   dynamic meta;
-  bool error;
+  bool? error;
 
   TypeDescriptor({
-    @required this.type,
+    required this.type,
     this.payload,
     this.meta,
     this.error,

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -1,7 +1,5 @@
 import 'dart:convert';
 
-import 'package:redux/redux.dart';
-
 import 'package:http/http.dart' as http;
 import 'package:redux_api_middleware/src/errors.dart';
 import 'package:redux_api_middleware/src/type_descriptor.dart';
@@ -51,9 +49,9 @@ List<TypeDescriptor> normalizeTypeDescriptors(List<dynamic> types) {
 }
 
 Future<Map<String, dynamic>> actionWith(TypeDescriptor descriptor,
-    [Map<String, dynamic> action,
+    [Map<String, dynamic>? action,
     dynamic state,
-    http.StreamedResponse response]) async {
+    http.StreamedResponse? response]) async {
   try {
     descriptor.payload = descriptor.payload is Function
         ? await descriptor.payload(action, state, response)

--- a/lib/src/validation.dart
+++ b/lib/src/validation.dart
@@ -30,10 +30,7 @@ const validCredentials = [
 ];
 
 bool isMap(obj) {
-  return (
-    obj != null &&
-    obj.entries != null
-  );
+  return (obj != null && obj.entries != null);
 }
 
 bool isRSAA(action) {
@@ -70,7 +67,8 @@ List<String> validateRSAA(action) {
   List<String> errors = [];
 
   if (!isRSAA(action)) {
-    errors.add('RSAAs must be Map<String, dynamic> objects with an [RSAA] property');
+    errors.add(
+        'RSAAs must be Map<String, dynamic> objects with an [RSAA] property');
   }
 
   var callAPI = action[RSAA];
@@ -80,7 +78,7 @@ List<String> validateRSAA(action) {
 
   for (var key in callAPI.keys) {
     if (!validCallAPIKeys.contains(key)) {
-      errors.add('Invalid [RSAA] key: ${key}');
+      errors.add('Invalid [RSAA] key: $key');
     }
   }
 
@@ -109,18 +107,20 @@ List<String> validateRSAA(action) {
   }
 
   if (headers != null && !isMap(headers) && headers is! Function) {
-    errors.add('[RSAA].headers property must be a Map<String, dynamic> object, or a Function');
+    errors.add(
+        '[RSAA].headers property must be a Map<String, dynamic> object, or a Function');
   }
 
   if (options != null && !isMap(options) && options is! Function) {
-    errors.add('[RSAA].options property must be a Map<String, dynamic> object, or a Function');
+    errors.add(
+        '[RSAA].options property must be a Map<String, dynamic> object, or a Function');
   }
 
   if (credentials != null) {
     if (credentials is! String) {
       errors.add('[RSAA].credentials property must be a String');
     } else if (!validCredentials.contains(credentials)) {
-      errors.add('Invalid [RSAA].credentials: ${credentials}');
+      errors.add('Invalid [RSAA].credentials: $credentials');
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,11 @@
 name: redux_api_middleware
 description: A dart redux middleware for calling APIs. APIs interact with reducers made easy..
 homepage: https://github.com/carloslira/redux_api_middleware
-version: 0.2.1
+version: 0.3.0
 
 environment:
-  sdk: ">=2.2.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  meta: ">=1.0.0 <2.0.0"
-  redux: ">=4.0.0 <5.0.0"
-  http: ^0.12.0+4
+  redux: ">=5.0.0 <6.0.0"
+  http: ">=0.13.0 <0.14.0"


### PR DESCRIPTION
This migrates the package to full null-safety so that people that depend on it can upgrade their flutter version. (I made this for my project and it works as expected [as this project doesnt have automated tests])